### PR TITLE
Refactor ID handling in mappers and documents to use ObjectId for Mon…

### DIFF
--- a/src/main/java/com/accenture/FranquiciaCore/domain/shared/util/IdGenerator.java
+++ b/src/main/java/com/accenture/FranquiciaCore/domain/shared/util/IdGenerator.java
@@ -1,9 +1,9 @@
 package com.accenture.franquiciaCore.domain.shared.util;
 
-import java.util.UUID;
+import org.bson.types.ObjectId;
 
 public final class IdGenerator {
   public static String generate() {
-    return UUID.randomUUID().toString();
+    return new ObjectId().toString();
   }
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/FranchiseMapper.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/FranchiseMapper.java
@@ -3,18 +3,19 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.mapper;
 import com.accenture.franquiciaCore.domain.franchise.model.Franchise;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.FranchiseId;
 import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.FranchiseDocument;
+import org.bson.types.ObjectId;
 
 public class FranchiseMapper {
     public static Franchise toDomain(FranchiseDocument doc) {
         return Franchise.builder()
-                .id(new FranchiseId(doc.getId()))
+                .id(new FranchiseId(doc.getId().toString()))
                 .name(doc.getName())
                 .build();
     }
 
     public static FranchiseDocument toDocument(Franchise franchise) {
         return FranchiseDocument.builder()
-                .id(franchise.getId().toString())
+                .id(new ObjectId(franchise.getId().toString()))
                 .name(franchise.getName())
                 .build();
     }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/ProductMapper.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/ProductMapper.java
@@ -7,29 +7,35 @@ import com.accenture.franquiciaCore.domain.franchise.valueobject.ProductId;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.StockId;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.SubsidiaryId;
 import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.ProductDocument;
+import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.SubsidiaryDocument;
 import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.StockDocument;
+import org.bson.types.ObjectId;
+import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.FranchiseDocument;
 
 public class ProductMapper {
     public static Product toDomain(ProductDocument doc) {
         return Product.builder()
-                .id(new ProductId(doc.getId()))
+                .id(new ProductId(doc.getId().toString()))
                 .name(doc.getName())
                 .category(CategoryProduct.valueOf(doc.getCategory()))
                 .stock(Stock.builder()
-                        .id(new StockId(doc.getStock().getId()))
+                        .id(new StockId(doc.getStock().getId().toString()))
                         .quantity(doc.getStock().getQuantity())
                         .build())
-                .subsidiaryId(new SubsidiaryId(doc.getSubsidiaryId()))
+                .subsidiaryId(new SubsidiaryId(doc.getSubsidiary().getId().toString()))
                 .build();
     }
 
     public static ProductDocument toDocument(Product product) {
         return ProductDocument.builder()
-                .id(product.getId().toString())
+                .id(new ObjectId(product.getId().toString()))
                 .name(product.getName())
                 .category(product.getCategory().name())
                 .stock(StockDocument.builder().quantity(product.getStock().getQuantity()).build())
-                .subsidiaryId(product.getSubsidiaryId().toString())
+                .subsidiary(SubsidiaryDocument.builder()
+                    .id(new ObjectId(product.getSubsidiaryId().toString()))
+                    .name(product.getSubsidiaryId().toString())
+                    .build())
                 .build();
     }
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/StockMapper.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/StockMapper.java
@@ -3,18 +3,19 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.mapper;
 import com.accenture.franquiciaCore.domain.franchise.model.Stock;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.StockId;
 import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.StockDocument;
+import org.bson.types.ObjectId;
 
 public class StockMapper {
   public static Stock toDomain(StockDocument doc) {
     return Stock.builder()
-        .id(new StockId(doc.getId()))
+        .id(new StockId(doc.getId().toString()))
         .quantity(doc.getQuantity())
         .build();
   }
 
   public static StockDocument toDocument(Stock stock) {
     return StockDocument.builder()
-        .id(stock.getId().toString())
+        .id(new ObjectId(stock.getId().toString()))
         .quantity(stock.getQuantity())
         .build();
   }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/SubsidiaryMapper.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/mapper/SubsidiaryMapper.java
@@ -3,22 +3,24 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.mapper;
 import com.accenture.franquiciaCore.domain.franchise.model.Subsidiary;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.FranchiseId;
 import com.accenture.franquiciaCore.domain.franchise.valueobject.SubsidiaryId;
+import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.FranchiseDocument;
 import com.accenture.franquiciaCore.infrastructure.persistence.mongo.model.SubsidiaryDocument;
+import org.bson.types.ObjectId;
 
 public class SubsidiaryMapper {
   public static Subsidiary toDomain(SubsidiaryDocument doc) {
     return Subsidiary.builder()
-        .id(new SubsidiaryId(doc.getId()))
+        .id(new SubsidiaryId(doc.getId().toString()))
         .name(doc.getName())
-        .franchiseId(new FranchiseId(doc.getFranchiseId()))
+        .franchiseId(new FranchiseId(doc.getFranchise().getId().toString()))
         .build();
   }
 
   public static SubsidiaryDocument toDocument(Subsidiary subsidiary) {
     return SubsidiaryDocument.builder()
-        .id(subsidiary.getId().toString())
+        .id(new ObjectId(subsidiary.getId().toString()))
         .name(subsidiary.getName())
-        .franchiseId(subsidiary.getFranchiseId().toString())
+        .franchise(new FranchiseDocument(new ObjectId(subsidiary.getFranchiseId().toString()), subsidiary.getFranchiseId().toString()))
         .build();
   }
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/FranchiseDocument.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/FranchiseDocument.java
@@ -3,6 +3,7 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.model;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.bson.types.ObjectId;
 
 @Document(collection = "franchises")
 @Data
@@ -11,6 +12,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 public class FranchiseDocument {
     @Id
-    private String id;
+    private ObjectId id;
     private String name;
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/ProductDocument.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/ProductDocument.java
@@ -2,7 +2,9 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.model;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.bson.types.ObjectId;
 
 @Document(collection = "products")
 @Data
@@ -11,9 +13,10 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 public class ProductDocument {
     @Id
-    private String id;
+    private ObjectId id;
     private String name;
     private String category;
     private StockDocument stock;
-    private String subsidiaryId;
+    @DBRef(lazy = true)
+    private SubsidiaryDocument subsidiary;
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/StockDocument.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/StockDocument.java
@@ -3,6 +3,8 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.model;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.bson.types.ObjectId;
 
 @Document(collection = "stocks")
 @Data
@@ -11,7 +13,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 public class StockDocument {
     @Id
-    private String id;
-    private String productId;
+    private ObjectId id;
+    @DBRef(lazy = true)
+    private ProductDocument product;
     private int quantity;
 }

--- a/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/SubsidiaryDocument.java
+++ b/src/main/java/com/accenture/FranquiciaCore/infrastructure/persistence/mongo/model/SubsidiaryDocument.java
@@ -2,8 +2,9 @@ package com.accenture.franquiciaCore.infrastructure.persistence.mongo.model;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
-
+import org.bson.types.ObjectId;
 @Document(collection = "subsidaries")
 @Data
 @NoArgsConstructor
@@ -11,7 +12,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 public class SubsidiaryDocument {
   @Id
-  private String id;
+  private ObjectId id;
   private String name;
-  private String franchiseId;
+  
+  @DBRef(lazy = true)
+  private FranchiseDocument franchise;
 }


### PR DESCRIPTION
…goDB compatibility

Updated IdGenerator to generate ObjectId instead of UUID. Modified FranchiseMapper, ProductMapper, StockMapper, and SubsidiaryMapper to convert IDs to and from ObjectId. Adjusted FranchiseDocument, ProductDocument, StockDocument, and SubsidiaryDocument to use ObjectId for ID fields and established DBRef relationships for subsidiary and product references. This change enhances the integration with MongoDB and ensures consistent ID handling across the application.